### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,10 @@
 # Template Instructions
 
-1. Assign work item leads by their github handles in the [CODEOWNERS](./CODEOWNERS) file.
-2. Tag overseeing WG with that WG's tag (i.e. #ccwg)
-3. Assign orgs/teams within DIF and define openness to external PRs depending on IPR policy
-4. Get to definitioning. A starter document structure can be found in `single-file-test/spec.md`. This guide can be expanded and altered but following the high level structure will make it easier for readers to get up to speed with the profile.
-5. Configure GitPages!
+Use this repository template for DIF Special Interest Groups. It hosts the group's landing page. 
 
-## Spec-Up
-
-For spec-up setup, see the [spec-up readme](https://github.com/decentralized-identity/spec-up)
-TLDR run 
-
-Update "name" value in `package.json` and `package-lock.json` with the name of the project
-`npm install spec-up`
+1. Fork this repo
+2. In package.json, update group `name`, `homepage`, and `repository.url` 
+3. Add group images into `docs/images/`. This includes photos of chairs and the group images.
+4. update docs/index.html with group information
+5. Add chair github handles in the [CODEOWNERS](./CODEOWNERS) file.
+6. Configure github pages


### PR DESCRIPTION
The current instructions are wrong. I fixed it with what I think is correct, but I'm not fully sure. Some points/questions:

- Why are there 2 branches? The site is served out of gh-pages
- SIGs don't create specs, so I removed everything referencing that
- I think we should add a creative commons license file by default in SIGs?
- What's involved with step #6?
- We should also check the charter or charter link in here, right?